### PR TITLE
Field information in table format

### DIFF
--- a/fields.csv
+++ b/fields.csv
@@ -1,8 +1,8 @@
 name,type,unit,bits,step,offset,count,min,max
 version,number,,8,1,0,=2^D2,=0+F2,=((G2-1)*E2)+F2
 flags,bitset,,8,1,0,=2^D3,=0+F3,=((G3-1)*E3)+F3
-diameter,number,mm,9,0.1,0,=2^D4,=0+F4,=((G4-1)*E4)+F4
-tolerance,number,mm,7,0.1,0,=2^D5,=0+F5,=((G5-1)*E5)+F5
+diameter,number,mm,9,0.1,0.1,=2^D4,=0+F4,=((G4-1)*E4)+F4
+tolerance,number,mm,7,0.1,0.1,=2^D5,=0+F5,=((G5-1)*E5)+F5
 glass,number,°C,8,1,0,=2^D6,=0+F6,=((G6-1)*E6)+F6
 print,number,°C,8,1,100,=2^D7,=0+F7,=((G7-1)*E7)+F7
 min,number,°C,8,1,50,=2^D8,=0+F8,=((G8-1)*E8)+F8

--- a/fields.csv
+++ b/fields.csv
@@ -2,7 +2,7 @@ name,type,unit,bits,step,offset,count,min,max
 version,number,,8,1,0,=2^D2,=0+F2,=((G2-1)*E2)+F2
 flags,bitset,,8,1,0,=2^D3,=0+F3,=((G3-1)*E3)+F3
 diameter,number,mm,9,0.01,0.1,=2^D4,=0+F4,=((G4-1)*E4)+F4
-tolerance,number,mm rms,7,0.1,0.1,=2^D5,=0+F5,=((G5-1)*E5)+F5
+tolerance,number,mm rms,6,0.01,0,=2^D5,=0+F5,=((G5-1)*E5)+F5
 vicat/glass,number,°C,10,1,-100,=2^D6,=0+F6,=((G6-1)*E6)+F6
 heat capacity,number,J/(mol K),,,,,,
 expansion coefficient,number,1/ºC,,,,,,

--- a/fields.csv
+++ b/fields.csv
@@ -6,7 +6,7 @@ tolerance,number,mm,7,0.1,0.1,=2^D5,=0+F5,=((G5-1)*E5)+F5
 glass,number,°C,8,1,0,=2^D6,=0+F6,=((G6-1)*E6)+F6
 print,number,°C,8,1,100,=2^D7,=0+F7,=((G7-1)*E7)+F7
 min,number,°C,8,1,50,=2^D8,=0+F8,=((G8-1)*E8)+F8
-max,number,°C,8,2,0,=2^D9,=0+F9,=((G9-1)*E9)+F9
+max,number,°C,7,2,0,=2^D9,=0+F9,=((G9-1)*E9)+F9
 chamber,number,°C,8,1,0,=2^D10,=0+F10,=((G10-1)*E10)+F10
 bed,number,°C,8,1,0,=2^D11,=0+F11,=((G11-1)*E11)+F11
 color,color,rbg,24,1,0,=2^D12,=0+F12,=((G12-1)*E12)+F12

--- a/fields.csv
+++ b/fields.csv
@@ -9,12 +9,16 @@ min,number,°C,8,1,50,=2^D8,=0+F8,=((G8-1)*E8)+F8
 max,number,°C,7,2,0,=2^D9,=0+F9,=((G9-1)*E9)+F9
 chamber,number,°C,8,1,0,=2^D10,=0+F10,=((G10-1)*E10)+F10
 bed,number,°C,8,1,0,=2^D11,=0+F11,=((G11-1)*E11)+F11
-color,color,rgb,12,1,0,=2^D12,=0+F12,=((G12-1)*E12)+F12
-opacity,number,%,4,10,0,=2^D13,=0+F13,=((G13-1)*E13)+F13
-properties,bitset,,5,1,0,=2^D14,=0+F14,=((G14-1)*E14)+F14
-mixture,category,,8,1,0,=2^D15,=0+F15,=((G15-1)*E15)+F15
-volume,number,cc,16,0.1,0,=2^D16,=0+F16,=((G16-1)*E16)+F16
-code,number,,40,1,0,=2^D17,=0+F17,=((G17-1)*E17)+F17
+reflectance red,number,%,4,6.25,0,=2^D12,=0+F12,=((G12-1)*E12)+F12
+reflectance green,number,%,4,6.25,0,=2^D13,=0+F13,=((G13-1)*E13)+F13
+reflectance blue,number,%,4,6.25,0,=2^D14,=0+F14,=((G14-1)*E14)+F14
+transmittance red,number,%,4,6.25,0,=2^D15,=0+F15,=((G15-1)*E15)+F15
+transmittance green,number,%,4,6.25,0,=2^D16,=0+F16,=((G16-1)*E16)+F16
+transmittance blue,number,%,4,6.25,0,=2^D17,=0+F17,=((G17-1)*E17)+F17
+properties,bitset,,5,1,0,=2^D18,=0+F18,=((G18-1)*E18)+F18
+mixture,category,,8,1,0,=2^D19,=0+F19,=((G19-1)*E19)+F19
+volume,number,cc,16,0.1,0,=2^D20,=0+F20,=((G20-1)*E20)+F20
+code,number,,40,1,0,=2^D21,=0+F21,=((G21-1)*E21)+F21
 ,,,,,,,,
-TOTAL bits,,,=SUM(D2:D17),,,,,
-TOTAL bytes,,,=D19/8,,,,,
+TOTAL bits,,,=SUM(D2:D21),,,,,
+TOTAL bytes,,,=D23/8,,,,,

--- a/fields.csv
+++ b/fields.csv
@@ -4,21 +4,25 @@ flags,bitset,,8,1,0,=2^D3,=0+F3,=((G3-1)*E3)+F3
 diameter,number,mm,9,0.1,0.1,=2^D4,=0+F4,=((G4-1)*E4)+F4
 tolerance,number,mm rms,7,0.1,0.1,=2^D5,=0+F5,=((G5-1)*E5)+F5
 vicat/glass,number,°C,10,1,-100,=2^D6,=0+F6,=((G6-1)*E6)+F6
-print,number,°C,8,1,100,=2^D7,=0+F7,=((G7-1)*E7)+F7
-min,number,°C,8,1,50,=2^D8,=0+F8,=((G8-1)*E8)+F8
-max,number,°C,7,2,0,=2^D9,=0+F9,=((G9-1)*E9)+F9
-chamber,number,°C,8,1,0,=2^D10,=0+F10,=((G10-1)*E10)+F10
-bed,number,°C,8,1,0,=2^D11,=0+F11,=((G11-1)*E11)+F11
-reflectance red,number,%,4,6.25,0,=2^D12,=0+F12,=((G12-1)*E12)+F12
-reflectance green,number,%,4,6.25,0,=2^D13,=0+F13,=((G13-1)*E13)+F13
-reflectance blue,number,%,4,6.25,0,=2^D14,=0+F14,=((G14-1)*E14)+F14
-transmittance red,number,%,4,6.25,0,=2^D15,=0+F15,=((G15-1)*E15)+F15
-transmittance green,number,%,4,6.25,0,=2^D16,=0+F16,=((G16-1)*E16)+F16
-transmittance blue,number,%,4,6.25,0,=2^D17,=0+F17,=((G17-1)*E17)+F17
-properties,bitset,,5,1,0,=2^D18,=0+F18,=((G18-1)*E18)+F18
-mixture,category,,8,1,0,=2^D19,=0+F19,=((G19-1)*E19)+F19
-volume,number,cc,16,0.1,0,=2^D20,=0+F20,=((G20-1)*E20)+F20
-code,number,,40,1,0,=2^D21,=0+F21,=((G21-1)*E21)+F21
+heat capacity,number,J/(mol K),,,,,,
+expansion coefficient,number,1/ºC,,,,,,
+melt flow index,number,g,,,,,,
+thermal conductivity,number,W/(m K),,,,,,
+print,number,°C,8,1,100,=2^D11,=0+F11,=((G11-1)*E11)+F11
+min,number,°C,8,1,50,=2^D12,=0+F12,=((G12-1)*E12)+F12
+max,number,°C,7,2,0,=2^D13,=0+F13,=((G13-1)*E13)+F13
+chamber,number,°C,8,1,0,=2^D14,=0+F14,=((G14-1)*E14)+F14
+bed,number,°C,8,1,0,=2^D15,=0+F15,=((G15-1)*E15)+F15
+reflectance red,number,%,4,6.25,0,=2^D16,=0+F16,=((G16-1)*E16)+F16
+reflectance green,number,%,4,6.25,0,=2^D17,=0+F17,=((G17-1)*E17)+F17
+reflectance blue,number,%,4,6.25,0,=2^D18,=0+F18,=((G18-1)*E18)+F18
+transmittance red,number,%,4,6.25,0,=2^D19,=0+F19,=((G19-1)*E19)+F19
+transmittance green,number,%,4,6.25,0,=2^D20,=0+F20,=((G20-1)*E20)+F20
+transmittance blue,number,%,4,6.25,0,=2^D21,=0+F21,=((G21-1)*E21)+F21
+properties,bitset,,5,1,0,=2^D22,=0+F22,=((G22-1)*E22)+F22
+mixture,category,,8,1,0,=2^D23,=0+F23,=((G23-1)*E23)+F23
+volume,number,cc,16,0.1,0,=2^D24,=0+F24,=((G24-1)*E24)+F24
+code,number,,40,1,0,=2^D25,=0+F25,=((G25-1)*E25)+F25
 ,,,,,,,,
-TOTAL bits,,,=SUM(D2:D21),,,,,
-TOTAL bytes,,,=D23/8,,,,,
+TOTAL bits,,,=SUM(D2:D25),,,,,
+TOTAL bytes,,,=D27/8,,,,,

--- a/fields.csv
+++ b/fields.csv
@@ -3,7 +3,7 @@ version,number,,8,1,0,=2^D2,=0+F2,=((G2-1)*E2)+F2
 flags,bitset,,8,1,0,=2^D3,=0+F3,=((G3-1)*E3)+F3
 diameter,number,mm,9,0.1,0.1,=2^D4,=0+F4,=((G4-1)*E4)+F4
 tolerance,number,mm rms,7,0.1,0.1,=2^D5,=0+F5,=((G5-1)*E5)+F5
-glass,number,°C,8,1,0,=2^D6,=0+F6,=((G6-1)*E6)+F6
+vicat/glass,number,°C,10,1,-100,=2^D6,=0+F6,=((G6-1)*E6)+F6
 print,number,°C,8,1,100,=2^D7,=0+F7,=((G7-1)*E7)+F7
 min,number,°C,8,1,50,=2^D8,=0+F8,=((G8-1)*E8)+F8
 max,number,°C,7,2,0,=2^D9,=0+F9,=((G9-1)*E9)+F9

--- a/fields.csv
+++ b/fields.csv
@@ -1,0 +1,20 @@
+name,type,unit,bits,step,offset,count,min,max
+version,number,,8,1,0,=2^D2,=0+F2,=((G2-1)*E2)+F2
+flags,bitset,,8,1,0,=2^D3,=0+F3,=((G3-1)*E3)+F3
+diameter,number,mm,9,0.1,0,=2^D4,=0+F4,=((G4-1)*E4)+F4
+tolerance,number,mm,7,0.1,0,=2^D5,=0+F5,=((G5-1)*E5)+F5
+glass,number,°C,8,1,0,=2^D6,=0+F6,=((G6-1)*E6)+F6
+print,number,°C,8,1,100,=2^D7,=0+F7,=((G7-1)*E7)+F7
+min,number,°C,8,1,50,=2^D8,=0+F8,=((G8-1)*E8)+F8
+max,number,°C,8,2,0,=2^D9,=0+F9,=((G9-1)*E9)+F9
+chamber,number,°C,8,1,0,=2^D10,=0+F10,=((G10-1)*E10)+F10
+bed,number,°C,8,1,0,=2^D11,=0+F11,=((G11-1)*E11)+F11
+color,color,rbg,24,1,0,=2^D12,=0+F12,=((G12-1)*E12)+F12
+opacity,number,%,3,=100/(G13-1),0,=2^D13,=0+F13,=((G13-1)*E13)+F13
+properties,bitset,,5,1,0,=2^D14,=0+F14,=((G14-1)*E14)+F14
+mixture,category,,8,1,0,=2^D15,=0+F15,=((G15-1)*E15)+F15
+volume,number,cc,16,0.1,0,=2^D16,=0+F16,=((G16-1)*E16)+F16
+code,number,,40,1,0,=2^D17,=0+F17,=((G17-1)*E17)+F17
+,,,,,,,,
+TOTAL bits,,,=SUM(D2:D17),,,,,
+TOTAL bytes,,,=D19/8,,,,,

--- a/fields.csv
+++ b/fields.csv
@@ -9,8 +9,8 @@ min,number,°C,8,1,50,=2^D8,=0+F8,=((G8-1)*E8)+F8
 max,number,°C,7,2,0,=2^D9,=0+F9,=((G9-1)*E9)+F9
 chamber,number,°C,8,1,0,=2^D10,=0+F10,=((G10-1)*E10)+F10
 bed,number,°C,8,1,0,=2^D11,=0+F11,=((G11-1)*E11)+F11
-color,color,rbg,24,1,0,=2^D12,=0+F12,=((G12-1)*E12)+F12
-opacity,number,%,3,=100/(G13-1),0,=2^D13,=0+F13,=((G13-1)*E13)+F13
+color,color,rgb,12,1,0,=2^D12,=0+F12,=((G12-1)*E12)+F12
+opacity,number,%,4,10,0,=2^D13,=0+F13,=((G13-1)*E13)+F13
 properties,bitset,,5,1,0,=2^D14,=0+F14,=((G14-1)*E14)+F14
 mixture,category,,8,1,0,=2^D15,=0+F15,=((G15-1)*E15)+F15
 volume,number,cc,16,0.1,0,=2^D16,=0+F16,=((G16-1)*E16)+F16

--- a/fields.csv
+++ b/fields.csv
@@ -1,7 +1,7 @@
 name,type,unit,bits,step,offset,count,min,max
 version,number,,8,1,0,=2^D2,=0+F2,=((G2-1)*E2)+F2
 flags,bitset,,8,1,0,=2^D3,=0+F3,=((G3-1)*E3)+F3
-diameter,number,mm,9,0.1,0.1,=2^D4,=0+F4,=((G4-1)*E4)+F4
+diameter,number,mm,9,0.01,0.1,=2^D4,=0+F4,=((G4-1)*E4)+F4
 tolerance,number,mm rms,7,0.1,0.1,=2^D5,=0+F5,=((G5-1)*E5)+F5
 vicat/glass,number,°C,10,1,-100,=2^D6,=0+F6,=((G6-1)*E6)+F6
 heat capacity,number,J/(mol K),,,,,,

--- a/fields.csv
+++ b/fields.csv
@@ -2,7 +2,7 @@ name,type,unit,bits,step,offset,count,min,max
 version,number,,8,1,0,=2^D2,=0+F2,=((G2-1)*E2)+F2
 flags,bitset,,8,1,0,=2^D3,=0+F3,=((G3-1)*E3)+F3
 diameter,number,mm,9,0.1,0.1,=2^D4,=0+F4,=((G4-1)*E4)+F4
-tolerance,number,mm,7,0.1,0.1,=2^D5,=0+F5,=((G5-1)*E5)+F5
+tolerance,number,mm rms,7,0.1,0.1,=2^D5,=0+F5,=((G5-1)*E5)+F5
 glass,number,°C,8,1,0,=2^D6,=0+F6,=((G6-1)*E6)+F6
 print,number,°C,8,1,100,=2^D7,=0+F7,=((G7-1)*E7)+F7
 min,number,°C,8,1,50,=2^D8,=0+F8,=((G8-1)*E8)+F8


### PR DESCRIPTION
I've created fields.csv to hold information about the spec in a compact, machine-readable format. It shows the range of possible values for each field, and how they are calculated. It also shows data types and units. This file could be used to help generate user interfaces and prose documentation, especially if we add a description column. I think it's better to generate certain parts of the code and documentation from data than to try to keep them in sync manually.

I created the file to match the current RC1 document, and than added commits for individual changes I'm proposing. I've added some fields and changed the size or range of others. This is partly based on a conversation with Lance from MadeSolid, although he has not reviewed the result. Some fields still need to be filled in.

I don't necessarily expect this to be merged wholesale. I'm submitting it so it can be reviewed and commented.
